### PR TITLE
fix: 'mirror source' typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The input variables, with their default values:
 | `email`                  | based on the `organization` | Email for `CODE_OF_CONDUCT.md`, `SECURITY.md` files and to specify the ownership of the project in `pyproject.toml`.                                                                                |
 | `version`                |           `0.1.0`           | Initial version of the package. Make sure it follows the [Semantic Versions](https://semver.org/) specification.                                                                                    |
 | `line_length`            |             88              | The max length per line (used for codestyle with `black` and `isort`). NOTE: This value must be between 50 and 300.                                                                                 |
-| `using_tsinghua_image_source`            |            false            | The tsinghua poetry image source                                                                                                                                                                    |
+| `using_tsinghua_mirror_source`            |            false            | The tsinghua poetry mirror source                                                                                                                                                                    |
 | `create_example_template` |            `cli`            | If `cli` is chosen generator will create simple CLI application with [`Typer`](https://github.com/tiangolo/typer) and [`Rich`](https://github.com/willmcgugan/rich) libraries. One of `cli`, `none` |
 
 All input values will be saved in the `cookiecutter-config-file.yml` file so that you won't lose them. 😉

--- a/README_zh.md
+++ b/README_zh.md
@@ -83,7 +83,7 @@ p3g generate
 | `email`                  | 基于 `organization` | 用于 `CODE_OF_CONDUCT.md`、`SECURITY.md` 文件和在 `pyproject.toml` 中指定项目所有权的电子邮件。                                                                                |
 | `version`                |           `0.1.0`           | 包的初始版本。确保它遵循 [Semantic Versions](https://semver.org/) 规范。                                                                                    |
 | `line_length`            |             88              | 每行的最大长度（用于 `black` 和 `isort` 的代码风格）。注意：此值必须在 50 到 300 之间。                                                                                 |
-| `using_tsinghua_image_source`            |            false            | 清华 poetry 镜像源                                                                                                                                                                    |
+| `using_tsinghua_mirror_source`            |            false            | 清华 poetry 镜像源                                                                                                                                                                    |
 | `create_example_template` |            `cli`            | 如果选择 `cli`，生成器将创建一个简单的 CLI 应用程序，使用 [`Typer`](https://github.com/tiangolo/typer) 和 [`Rich`](https://github.com/willmcgugan/rich) 库。`cli` 和 `none` 中的一个 |
 
 所有输入值将保存在 `cookiecutter-config-file.yml` 文件中，这样你就不会丢失它们。😉

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,7 +9,7 @@
   "email": "hello@{{ cookiecutter.organization.lower().replace(' ', '-') }}.com",
   "version": "0.1.0",
   "line_length": 88,
-  "using_tsinghua_image_source": false,
+  "using_tsinghua_mirror_source": false,
   "install_ruff": true,
   "install_pre_commit": true,
   "install_coverage": true,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "p3g"
-version = "1.3.1"
+version = "1.3.2"
 description = "Python Packages Project Generator"
 readme = "README.md"
 authors = ["Zeeland <zeeland4work@gmail.com>"]

--- a/{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/pyproject.toml
+++ b/{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [  #! Update me
 # Entry points for the package https://python-poetry.org/docs/pyproject/#scripts
 "{{ cookiecutter.project_name }}" = "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}.__main__:app"{%- endif %}
 
-{% if cookiecutter.using_tsinghua_image_source -%}
+{% if cookiecutter.using_tsinghua_mirror_source -%}
 [[tool.poetry.source]]
 name = "tsinghua"
 url = "https://pypi.tuna.tsinghua.edu.cn/simple"


### PR DESCRIPTION
## Description

Fix typo, changing "image source" to "mirror source"。

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->
None

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Undertone0809/python-package-template/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/Undertone0809/python-package-template/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in `Google` format for all the methods and classes that I used.
