### PR TITLE
Fix for bug introduced in 'refactor: optimize cli usage #117'

### DIFF
--- a/p3g/client.py
+++ b/p3g/client.py
@@ -24,7 +24,7 @@ def main():
 
 def generate_proj():
     subprocess.run(
-        ["cookiecutter", "gh:Undertone0809/P3G", "--checkout", version("p3g")]
+        ["cookiecutter", "gh:Undertone0809/P3G", "--checkout", "v" + version("p3g")]
     )
 
 


### PR DESCRIPTION
## Description

This PR addresses the bug introduced in https://github.com/Undertone0809/P3G/pull/117

Essentially the version tag is missing the `v` prefix which are used to denote P3G release tags.

## Related Issue

https://github.com/Undertone0809/P3G/pull/117

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [X] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [X] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Undertone0809/python-package-template/blob/main/CODE_OF_CONDUCT.md) document.
- [X] I've read the [`CONTRIBUTING.md`](https://github.com/Undertone0809/python-package-template/blob/main/CONTRIBUTING.md) guide.
- [X] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in `Google` format for all the methods and classes that I used.
