### PR TITLE
chore: update project version and rename Makefile target

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "p3g"
-version = "1.3.5"
+version = "1.3.6"
 description = "Python Packages Project Generator"
 readme = "README.md"
 authors = ["Zeeland <zeeland4work@gmail.com>"]

--- a/{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/Makefile
+++ b/{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/Makefile
@@ -15,7 +15,7 @@ endif
 IMAGE := {{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}
 VERSION := latest
 
-.PHONY: lock install {% if cookiecutter.install_pre_commit %}pre-commit-install{% endif %} polish-codestyle formatting test check-codestyle lint docker-build docker-remove cleanup help
+.PHONY: lock install {% if cookiecutter.install_pre_commit %}pre-commit-install{% endif %} formatting test check-codestyle lint docker-build docker-remove cleanup help
 
 lock:
 	poetry lock -n && poetry export --without-hashes > requirements.txt
@@ -29,12 +29,9 @@ pre-commit-install:
 	poetry run pre-commit install
 {%- endif %}
 
-polish-codestyle:
+format:
 	poetry run ruff format --config pyproject.toml .
 	poetry run ruff check --fix --config pyproject.toml .
-
-formatting: polish-codestyle
-format: polish-codestyle
 
 test:
 	$(TEST_COMMAND)
@@ -84,8 +81,7 @@ help:
 {%- if cookiecutter.install_pre_commit %}
 	@echo "pre-commit-install                        Install the pre-commit hooks."
 {%- endif %}
-	@echo "polish-codestyle                          Format the codebase."
-	@echo "formatting                                Format the codebase."
+	@echo "format                                    Format the codebase."
 	@echo "test                                      Run the tests."
 	@echo "check-codestyle                           Check the codebase for style issues."
 	@echo "lint                                      Run the tests and check the codebase for style issues."

--- a/{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/README.md
+++ b/{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/README.md
@@ -81,9 +81,6 @@ make pre-commit-install
 Automatic formatting uses `ruff`.
 
 ```bash
-make polish-codestyle
-
-# or use synonym
 make format
 ```
 


### PR DESCRIPTION
- Bump project version to 1.3.6 in pyproject.toml
- Rename 'polish-codestyle' target to 'format' in Makefile
- Update README.md to reflect the new 'format' target

This change streamlines the code formatting process and updates the project version to reflect recent changes.